### PR TITLE
refactor(chain): pluggable crypto abstraction (ECDSA default, Dilithium placeholder)

### DIFF
--- a/crates/chain/src/crypto/dilithium.rs
+++ b/crates/chain/src/crypto/dilithium.rs
@@ -1,0 +1,7 @@
+/// Placeholder Dilithium module.
+///
+/// The implementation is intentionally minimal and compile-safe so call-sites can
+/// switch by algorithm identifier without touching validation flow.
+pub fn verify_signature(_pubkey_bytes: &[u8], _msg: &[u8], _sig_bytes: &[u8]) -> bool {
+    false
+}

--- a/crates/chain/src/crypto/ecdsa.rs
+++ b/crates/chain/src/crypto/ecdsa.rs
@@ -1,0 +1,65 @@
+use anyhow::Result;
+use ed25519_dalek::{Keypair, PublicKey, SecretKey, Signature, Signer, Verifier};
+use rand_core::OsRng;
+
+use super::CryptoScheme;
+
+pub struct EcdsaImpl;
+
+impl CryptoScheme for EcdsaImpl {
+    type PublicKey = Vec<u8>;
+    type PrivateKey = Vec<u8>;
+    type Signature = Vec<u8>;
+
+    fn generate_keypair() -> (Self::PublicKey, Self::PrivateKey) {
+        let mut csprng = OsRng {};
+        let kp: Keypair = Keypair::generate(&mut csprng);
+        (kp.public.to_bytes().to_vec(), kp.to_bytes().to_vec())
+    }
+
+    fn sign(private: &Self::PrivateKey, message: &[u8]) -> Self::Signature {
+        sign_message_with_keypair_bytes(private, message).unwrap_or_default()
+    }
+
+    fn verify(public: &Self::PublicKey, message: &[u8], signature: &Self::Signature) -> bool {
+        verify_signature(public, message, signature).unwrap_or(false)
+    }
+}
+
+pub fn sign_with_secret_key(secret: &[u8], msg: &[u8]) -> Result<Vec<u8>> {
+    let secret_key = SecretKey::from_bytes(secret)
+        .map_err(|e| anyhow::anyhow!("invalid secret key: {}", e))?;
+    let public_key: PublicKey = (&secret_key).into();
+    let kp = Keypair { secret: secret_key, public: public_key };
+    let sig: Signature = kp.sign(msg);
+    Ok(sig.to_bytes().to_vec())
+}
+
+pub fn sign_message_with_keypair_bytes(keypair_bytes: &[u8], msg: &[u8]) -> Result<Vec<u8>> {
+    let kp = Keypair::from_bytes(keypair_bytes)
+        .map_err(|e| anyhow::anyhow!("invalid keypair bytes: {}", e))?;
+    let sig: Signature = kp.sign(msg);
+    Ok(sig.to_bytes().to_vec())
+}
+
+pub fn verify_signature(pubkey_bytes: &[u8], msg: &[u8], sig_bytes: &[u8]) -> Result<bool> {
+    let pk = PublicKey::from_bytes(pubkey_bytes)
+        .map_err(|e| anyhow::anyhow!("invalid public key: {}", e))?;
+    let sig = Signature::from_bytes(sig_bytes)
+        .map_err(|e| anyhow::anyhow!("invalid signature: {}", e))?;
+    Ok(pk.verify(msg, &sig).is_ok())
+}
+
+
+pub fn public_key_from_secret_key(secret: &[u8; 32]) -> Option<PublicKey> {
+    let sk = SecretKey::from_bytes(secret).ok()?;
+    Some(PublicKey::from(&sk))
+}
+
+pub fn public_key_from_secret(secret: &[u8; 32]) -> [u8; 32] {
+    let sk = match SecretKey::from_bytes(secret) {
+        Ok(sk) => sk,
+        Err(_) => return [0u8; 32],
+    };
+    PublicKey::from(&sk).to_bytes()
+}

--- a/crates/chain/src/miner.rs
+++ b/crates/chain/src/miner.rs
@@ -51,19 +51,17 @@ impl Miner {
     pub fn from_private(proposer: Address, private_key: Vec<u8>) -> Result<Self> {
         // If you don't want to use ed25519-dalek, remove this function.
         // Make sure to add `ed25519-dalek = "1.0.1"` to Cargo.toml if using.
-        use ed25519_dalek::SecretKey;
-
         if private_key.len() != 32 {
             return Err(anyhow!("private key must be 32 bytes (seed) to derive public key"));
         }
 
-        let secret = SecretKey::from_bytes(&private_key)
-            .map_err(|e| anyhow!("invalid secret key bytes: {}", e))?;
-        let public = ed25519_dalek::PublicKey::from(&secret);
+        let mut secret_arr = [0u8; 32];
+        secret_arr.copy_from_slice(&private_key);
+        let public = crate::crypto::ecdsa::public_key_from_secret(&secret_arr);
         Ok(Miner {
             proposer,
             private_key,
-            public_key: public.as_bytes().to_vec(),
+            public_key: public.to_vec(),
         })
     }
 


### PR DESCRIPTION
### Motivation

- Remove hardcoded Ed25519 usages and prepare chain crypto for multiple signature schemes while keeping ECDSA as the default for backward compatibility.
- Centralize signing/verification logic into a single extensible module so future algorithms (e.g., Dilithium) can be plugged in without large refactors.
- Preserve existing on-chain semantics and data formats where possible so business logic and consensus behavior are unchanged.

### Description

- Added a pluggable crypto architecture in `crates/chain/src/crypto.rs` including the `CryptoScheme` trait, `CryptoEngine<A>` generic wrapper, and `CryptoAlgorithm` enum (`Ecdsa`, `Dilithium`).
- Split concrete logic into `crates/chain/src/crypto/ecdsa.rs` (default implementation using ed25519-dalek) and a compile-safe placeholder `crates/chain/src/crypto/dilithium.rs` for future integration.
- Kept backward-compatible helpers (`generate_ed25519_keypair_bytes`, `sign_message_with_keypair_bytes`, `sign_ed25519`, `ed25519_verify`) that route through the new abstraction and keep default behavior as ECDSA.
- Made signature handling algorithm-aware in on-chain types by adding algorithm metadata (e.g., `coordinator_signature_algorithm` with `#[serde(default)]`) and dispatching verification via `verify_signature_with_algorithm(...)` (receipt verification updated accordingly).
- Refactored callers to use the new crypto helpers instead of direct ed25519_dalek calls, including `wallet.rs` (public-key derivation and verify flows) and `miner.rs` (public key derivation), avoiding scattered algorithm-specific logic.

### Testing

- Installed `cargo-rustsp` to enable the project's `cargo rustsp` workflow and used it to run the build/test loop.
- Ran `cargo rustsp build -p dsdn-chain` and the build completed successfully (no compile errors).
- Ran `cargo rustsp test -p dsdn-chain` and the test suite completed with tests ignored/skipped as before and no failures.
- Verified the repository builds in the local environment after the refactor and that the default ECDSA compatibility paths remain functional.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f1268ff648329b7991f6330af4c96)